### PR TITLE
Biras Raluca PR1

### DIFF
--- a/Input.cs
+++ b/Input.cs
@@ -1,36 +1,42 @@
 using Silk.NET.SDL;
+using System.IO;
+using System;
+using TheAdventure;
 
 namespace TheAdventure;
 
 public unsafe class Input
 {
     private readonly Sdl _sdl;
-    
+    private readonly GameRenderer _gameRenderer; // Added GameRenderer reference
+
     public EventHandler<(int x, int y)>? OnMouseClick;
-    
-    public Input(Sdl sdl)
+
+    // Updated constructor to inject GameRenderer
+    public Input(Sdl sdl, GameRenderer gameRenderer)
     {
         _sdl = sdl;
+        _gameRenderer = gameRenderer;
     }
-    
+
     public bool IsLeftPressed()
     {
         ReadOnlySpan<byte> keyboardState = new(_sdl.GetKeyboardState(null), (int)KeyCode.Count);
         return keyboardState[(int)KeyCode.Left] == 1;
     }
-        
+
     public bool IsRightPressed()
     {
         ReadOnlySpan<byte> keyboardState = new(_sdl.GetKeyboardState(null), (int)KeyCode.Count);
         return keyboardState[(int)KeyCode.Right] == 1;
     }
-        
+
     public bool IsUpPressed()
     {
         ReadOnlySpan<byte> keyboardState = new(_sdl.GetKeyboardState(null), (int)KeyCode.Count);
         return keyboardState[(int)KeyCode.Up] == 1;
     }
-        
+
     public bool IsDownPressed()
     {
         ReadOnlySpan<byte> keyboardState = new(_sdl.GetKeyboardState(null), (int)KeyCode.Count);
@@ -50,108 +56,28 @@ public unsafe class Input
             switch (ev.Type)
             {
                 case (uint)EventType.Windowevent:
-                {
-                    switch (ev.Window.Event)
-                    {
-                        case (byte)WindowEventID.Shown:
-                        case (byte)WindowEventID.Exposed:
-                        {
-                            break;
-                        }
-                        case (byte)WindowEventID.Hidden:
-                        {
-                            break;
-                        }
-                        case (byte)WindowEventID.Moved:
-                        {
-                            break;
-                        }
-                        case (byte)WindowEventID.SizeChanged:
-                        {
-                            break;
-                        }
-                        case (byte)WindowEventID.Minimized:
-                        case (byte)WindowEventID.Maximized:
-                        case (byte)WindowEventID.Restored:
-                            break;
-                        case (byte)WindowEventID.Enter:
-                        {
-                            break;
-                        }
-                        case (byte)WindowEventID.Leave:
-                        {
-                            break;
-                        }
-                        case (byte)WindowEventID.FocusGained:
-                        {
-                            break;
-                        }
-                        case (byte)WindowEventID.FocusLost:
-                        {
-                            break;
-                        }
-                        case (byte)WindowEventID.Close:
-                        {
-                            break;
-                        }
-                        case (byte)WindowEventID.TakeFocus:
-                        {
-                            _sdl.SetWindowInputFocus(_sdl.GetWindowFromID(ev.Window.WindowID));
-                            break;
-                        }
-                    }
-
+                    if (ev.Window.Event == (byte)WindowEventID.TakeFocus)
+                        _sdl.SetWindowInputFocus(_sdl.GetWindowFromID(ev.Window.WindowID));
                     break;
-                }
 
-                case (uint)EventType.Fingermotion:
-                {
-                    break;
-                }
-
-                case (uint)EventType.Mousemotion:
-                {
-                    break;
-                }
-
-                case (uint)EventType.Fingerdown:
-                {
-                    break;
-                }
                 case (uint)EventType.Mousebuttondown:
-                {
                     if (ev.Button.Button == (byte)MouseButton.Primary)
-                    {
                         OnMouseClick?.Invoke(this, (ev.Button.X, ev.Button.Y));
-                    }
-                    
                     break;
-                }
-
-                case (uint)EventType.Fingerup:
-                {
-                    break;
-                }
-
-                case (uint)EventType.Mousebuttonup:
-                {
-                    break;
-                }
-
-                case (uint)EventType.Mousewheel:
-                {
-                    break;
-                }
-
-                case (uint)EventType.Keyup:
-                {
-                    break;
-                }
 
                 case (uint)EventType.Keydown:
-                {
+                    var key = ev.Key.Keysym.Sym;
+                    if (key == (int)KeyCode.F12)
+                    {
+                        var screenshotDir = Path.Combine("Screenshots");
+                        Directory.CreateDirectory(screenshotDir);
+
+                        var filename = $"screenshot_{DateTime.Now:yyyyMMdd_HHmmss}.png";
+                        var fullPath = Path.Combine(screenshotDir, filename);
+
+                        _gameRenderer.CaptureScreenshot(fullPath);
+                    }
                     break;
-                }
             }
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -19,8 +19,9 @@ public static class Program
 
         using (var gameWindow = new GameWindow(sdl))
         {
-            var input = new Input(sdl);
             var gameRenderer = new GameRenderer(sdl, gameWindow);
+            var input = new Input(sdl, gameRenderer);
+
             var engine = new Engine(gameRenderer, input);
 
             engine.SetupWorld();


### PR DESCRIPTION
This commit adds a screenshot functionality triggered by the F12 key:
- Pressing F12 captures the current frame buffer.
- The screenshot is saved as a PNG image in a new "Screenshots" folder.
- Image is flipped vertically to correct SDL rendering orientation.

Changes made:
- Added `CaptureScreenshot` method in `GameRenderer`.
- Updated `Input` class to listen for F12 key presses.
- Injected `GameRenderer` into `Input` via constructor.

This enhancement touches input handling, rendering, and file I/O — and provides a user-facing utility that could be useful for debugging or sharing gameplay moments.
