### PR TITLE
Milan Daniel PR0

### DIFF
--- a/Engine.cs
+++ b/Engine.cs
@@ -21,6 +21,7 @@ public class Engine
     private PlayerObject? _player;
 
     private DateTimeOffset _lastUpdate = DateTimeOffset.Now;
+    private GameTimeManager _gameTimeManager = new();
 
     public Engine(GameRenderer renderer, Input input)
     {
@@ -82,6 +83,11 @@ public class Engine
         var currentTime = DateTimeOffset.Now;
         var msSinceLastFrame = (currentTime - _lastUpdate).TotalMilliseconds;
         _lastUpdate = currentTime;
+
+        float deltaTime = (float)msSinceLastFrame / 1000f;
+        _gameTimeManager.Update(deltaTime);
+        float brightness = _gameTimeManager.GetBrightnessFactor();
+        _renderer.SetBrightness(brightness);
 
         if (_player == null)
         {

--- a/GameRenderer.cs
+++ b/GameRenderer.cs
@@ -16,6 +16,7 @@ public unsafe class GameRenderer
 
     private Dictionary<int, IntPtr> _texturePointers = new();
     private Dictionary<int, TextureData> _textureData = new();
+    private float _brightnessFactor = 1.0f;
     private int _textureId;
 
     public GameRenderer(Sdl sdl, GameWindow window)
@@ -28,6 +29,10 @@ public unsafe class GameRenderer
         _window = window;
         var windowSize = window.Size;
         _camera = new Camera(windowSize.Width, windowSize.Height);
+    }
+public void SetBrightness(float factor)
+    {
+        _brightnessFactor = Math.Clamp(factor, 0.3f, 1.0f);
     }
 
     public void SetWorldBounds(Rectangle<int> bounds)
@@ -108,6 +113,22 @@ public unsafe class GameRenderer
 
     public void PresentFrame()
     {
+if (_brightnessFactor < 1.0f)
+        {
+            float alpha = 1.0f - _brightnessFactor;
+            DrawDarkOverlay(alpha);
+        }
         _sdl.RenderPresent(_renderer);
     }
+private void DrawDarkOverlay(float alpha)
+{
+    _sdl.SetRenderDrawBlendMode(_renderer, BlendMode.Blend);
+    _sdl.SetRenderDrawColor(_renderer, 0, 0, 0, (byte)(alpha * 255));
+
+    var windowSize = _window.Size;
+    var rect = new Silk.NET.Maths.Rectangle<int>(0, 0, windowSize.Width, windowSize.Height);
+
+    _sdl.RenderFillRect(_renderer, &rect);
+}
+
 }

--- a/GameTimeManager.cs
+++ b/GameTimeManager.cs
@@ -1,0 +1,20 @@
+using System;
+
+public class GameTimeManager
+{
+    private const float DayDurationSeconds = 60f;
+    private float elapsedTime = 0f;
+
+    public float TimeOfDayNormalized => (elapsedTime % DayDurationSeconds) / DayDurationSeconds;
+
+    public void Update(float deltaTime)
+    {
+        elapsedTime += deltaTime;
+    }
+
+    public float GetBrightnessFactor()
+    {
+        float t = TimeOfDayNormalized;
+        return (float)(0.5 + 0.5 * Math.Sin(2 * Math.PI * t));
+    }
+}

--- a/Utils.cs
+++ b/Utils.cs
@@ -1,0 +1,10 @@
+namespace TheAdventure
+{
+    public struct SDL_Rect
+    {
+        public int x;
+        public int y;
+        public int w;
+        public int h;
+    }
+}


### PR DESCRIPTION
Description:

I added a day/night cycle system that gradually adjusts the screen brightness based on in-game time.

New functionalities:

-     Smooth transition between day and night (full cycle ~60 seconds)

-     Dynamic overlay darkening based on time of day

-     Real-time updates with no input required from the player

Technical details:

-     New file: GameTimeManager.cs – manages in-game time and computes brightness factor

-     Engine.cs: integrates time updates and passes brightness value to the renderer

-     GameRenderer.cs: applies a semi-transparent black overlay to simulate night

https://github.com/user-attachments/assets/a28f98d9-f2f7-4335-bd34-e535126fdbb4

