### PR TITLE
Andrei-David Nan  - PR #3 |Added player collision detection with map edges

### DIFF
--- a/Engine.cs
+++ b/Engine.cs
@@ -95,12 +95,16 @@ public class Engine
         bool isAttacking = _input.IsKeyAPressed() && (up + down + left + right <= 1);
         bool addBomb = _input.IsKeyBPressed();
 
-        _player.UpdatePosition(up, down, left, right, 48, 48, msSinceLastFrame);
+        int mapWidth = _currentLevel.Width!.Value * _currentLevel.TileWidth!.Value;
+        int mapHeight = _currentLevel.Height!.Value * _currentLevel.TileHeight!.Value;
+
+        _player.UpdatePosition(up, down, left, right, 48, 48, msSinceLastFrame, mapWidth, mapHeight);
+
         if (isAttacking)
         {
             _player.Attack();
         }
-        
+
         _scriptEngine.ExecuteAll(this);
 
         if (addBomb)
@@ -108,7 +112,6 @@ public class Engine
             AddBomb(_player.Position.X, _player.Position.Y, false);
         }
     }
-
     public void RenderFrame()
     {
         _renderer.SetDrawColor(0, 0, 0, 255);

--- a/Models/PlayerObject.cs
+++ b/Models/PlayerObject.cs
@@ -82,7 +82,7 @@ public class PlayerObject : RenderableGameObject
         SetState(PlayerState.Attack, direction);
     }
 
-    public void UpdatePosition(double up, double down, double left, double right, int width, int height, double time)
+    public void UpdatePosition(double up, double down, double left, double right, int width, int height, double time, int mapWidth, int mapHeight)
     {
         if (State.State == PlayerState.GameOver)
         {
@@ -91,16 +91,43 @@ public class PlayerObject : RenderableGameObject
 
         var pixelsToMove = _speed * (time / 1000.0);
 
-        var x = Position.X + (int)(right * pixelsToMove);
-        x -= (int)(left * pixelsToMove);
+        var proposedX = Position.X + (int)(right * pixelsToMove);
+        proposedX -= (int)(left * pixelsToMove);
 
-        var y = Position.Y + (int)(down * pixelsToMove);
-        y -= (int)(up * pixelsToMove);
+        var proposedY = Position.Y + (int)(down * pixelsToMove);
+        proposedY -= (int)(up * pixelsToMove);
+
+        int finalX = proposedX;
+        int finalY = proposedY;
+
+        int spriteWidth = width;
+        int spriteHeight = height;
+
+        int anchorX = 24; // frameCenter.offsetX
+        int anchorY = 42; // frameCenter.offsetY
+
+        if (finalX - anchorX < 0)
+        {
+            finalX = anchorX;
+        }
+        else if (finalX - anchorX + spriteWidth > mapWidth)
+        {
+            finalX = mapWidth - spriteWidth + anchorX;
+        }
+
+        if (finalY - anchorY < 0)
+        {
+            finalY = anchorY;
+        }
+        else if (finalY - anchorY + spriteHeight > mapHeight)
+        {
+            finalY = mapHeight - spriteHeight + anchorY;
+        }
 
         var newState = State.State;
         var newDirection = State.Direction;
 
-        if (x == Position.X && y == Position.Y)
+        if (finalX == Position.X && finalY == Position.Y)
         {
             if (State.State == PlayerState.Attack)
             {
@@ -117,23 +144,23 @@ public class PlayerObject : RenderableGameObject
         else
         {
             newState = PlayerState.Move;
-            
-            if (y < Position.Y && newDirection != PlayerStateDirection.Up)
+
+            if (finalY < Position.Y && newDirection != PlayerStateDirection.Up)
             {
                 newDirection = PlayerStateDirection.Up;
             }
 
-            if (y > Position.Y && newDirection != PlayerStateDirection.Down)
+            if (finalY > Position.Y && newDirection != PlayerStateDirection.Down)
             {
                 newDirection = PlayerStateDirection.Down;
             }
 
-            if (x < Position.X && newDirection != PlayerStateDirection.Left)
+            if (finalX < Position.X && newDirection != PlayerStateDirection.Left)
             {
                 newDirection = PlayerStateDirection.Left;
             }
 
-            if (x > Position.X && newDirection != PlayerStateDirection.Right)
+            if (finalX > Position.X && newDirection != PlayerStateDirection.Right)
             {
                 newDirection = PlayerStateDirection.Right;
             }
@@ -144,6 +171,6 @@ public class PlayerObject : RenderableGameObject
             SetState(newState, newDirection);
         }
 
-        Position = (x, y);
+        Position = (finalX, finalY);
     }
 }


### PR DESCRIPTION
This is my 3rd PR since the earlier ones were a bit simpler. It adds collision detection to prevent the player from walking past the map edges. The issue was that the player could freely move outside the playable area and he could not come back. I added boundary checks in `PlayerObject.UpdatePosition` that respect the player's sprite dimensions and anchor points. Map dimensions are now properly calculated and passed from the `Engine` class to ensure the player stays within the valid game area at all times.

Name: Andrei-David Nan