### PR TITLE
PaunAlecsandraPR0

### DIFF
--- a/Engine.cs
+++ b/Engine.cs
@@ -28,6 +28,7 @@ public class Engine
         _input = input;
 
         _input.OnMouseClick += (_, coords) => AddBomb(coords.x, coords.y);
+
     }
 
     public void SetupWorld()
@@ -94,6 +95,10 @@ public class Engine
         double right = _input.IsRightPressed() ? 1.0 : 0.0;
         bool isAttacking = _input.IsKeyAPressed() && (up + down + left + right <= 1);
         bool addBomb = _input.IsKeyBPressed();
+        bool isReset = _input.IsKeyRPressed();
+        bool showHelp = _input.IsKeyHPressed();
+
+
 
         _player.UpdatePosition(up, down, left, right, 48, 48, msSinceLastFrame);
         if (isAttacking)
@@ -107,6 +112,17 @@ public class Engine
         {
             AddBomb(_player.Position.X, _player.Position.Y, false);
         }
+
+        if (isReset)
+        {
+            ResetPlayerPosition();
+        }
+
+        if (showHelp)
+        {
+            ShowHelpMenu();
+        }
+
     }
 
     public void RenderFrame()
@@ -215,4 +231,24 @@ public class Engine
         TemporaryGameObject bomb = new(spriteSheet, 2.1, (worldCoords.X, worldCoords.Y));
         _gameObjects.Add(bomb.Id, bomb);
     }
+
+    public void ResetPlayerPosition()
+    {
+        if (_player != null)
+        {
+            _player.Position = new(100, 100);
+        }
+    }
+
+    public void ShowHelpMenu()
+    {
+        Console.WriteLine("🎮 COMENZI DISPONIBILE:");
+        Console.WriteLine("⬅  ➡  ⬆  ⬇  — mișcare");
+        Console.WriteLine("[A] — atacă");
+        Console.WriteLine("[B] — plasează bombă");
+        Console.WriteLine("[R] — resetează poziția jucătorului");
+        Console.WriteLine("[H] — afișează acest meniu de ajutor");
+    }
+
+
 }

--- a/Input.cs
+++ b/Input.cs
@@ -49,6 +49,19 @@ public unsafe class Input
         return _keyboardState[(int)KeyCode.B] == 1;
     }
 
+    public bool IsKeyRPressed()
+    {
+        ReadOnlySpan<byte> keyboardState = new(_sdl.GetKeyboardState(null), (int)KeyCode.Count);
+        return keyboardState[(int)KeyCode.R] == 1;
+    }
+
+    public bool IsKeyHPressed()
+    {
+        ReadOnlySpan<byte> keyboardState = new(_sdl.GetKeyboardState(null), (int)KeyCode.Count);
+        return keyboardState[(int)KeyCode.H] == 1;
+    }
+
+
     public bool ProcessInput()
     {
         Event ev = new Event();


### PR DESCRIPTION
This PR introduces a new feature that allows the player to reset their position to the starting coordinates (100, 100) by pressing the `R` key during gameplay.

- Added `IsKeyRPressed()` in `Input.cs` to detect when the `R` key is pressed.
- Updated `Engine.cs`:
  - In `ProcessFrame()`, added logic to call `ResetPlayerPosition()` if `R` is pressed.
  - Added method `ResetPlayerPosition()` to set player position to (100, 100).

